### PR TITLE
Ajustes de diseño responsivo para la versión móvil

### DIFF
--- a/src/components/Chatbot.css
+++ b/src/components/Chatbot.css
@@ -65,6 +65,35 @@
     animation: fadeInScale 0.25s ease-out forwards;
 }
 
+@media (max-width: 640px) {
+    .chatbot-container {
+        bottom: calc(var(--spacing-xl) + 52px);
+        right: var(--spacing-md);
+    }
+
+    .chatbot-toggle-button {
+        width: 56px;
+        height: 56px;
+    }
+
+    .chat-window {
+        width: min(340px, 92vw);
+        height: 460px;
+    }
+}
+
+@media (max-width: 480px) {
+    .chatbot-container {
+        right: var(--spacing-sm);
+    }
+
+    .chat-window {
+        width: 92vw;
+        height: 70vh;
+        max-height: 520px;
+    }
+}
+
 @keyframes fadeInScale {
     from {
         opacity: 0;

--- a/src/components/EmergencyButton.css
+++ b/src/components/EmergencyButton.css
@@ -22,6 +22,16 @@
     transition: background-color 0.3s ease, transform 0.2s ease;
 }
 
+@media (max-width: 640px) {
+    .emergency-float-button {
+        width: 52px;
+        height: 52px;
+        font-size: 1.8em;
+        bottom: var(--spacing-md);
+        right: var(--spacing-md);
+    }
+}
+
 .emergency-float-button:hover {
     background-color: #c0392b; /* Rojo más oscuro al pasar el ratón */
     transform: scale(1.05); /* Ligeramente más grande */

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -331,7 +331,6 @@
     .header-actions {
         gap: var(--spacing-md);
     }
-}
 
     .header-message {
         max-width: 100%;
@@ -430,6 +429,7 @@
         gap: 10px;
         background: rgba(6, 182, 212, 0.18);
     }
+}
 
 @media (max-width: 640px) {
     .header-container {

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,7 @@ body {
     min-width: 0;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
 }
 
 #root, .App {
@@ -109,6 +110,8 @@ h6 { font-size: 1rem; }
     max-width: 1400px;
     width: 100%;
     margin: 0 auto;
+    padding-left: var(--spacing-xl);
+    padding-right: var(--spacing-xl);
     padding-top: calc(var(--header-height-desktop) + var(--spacing-lg));
     padding-bottom: var(--spacing-xl);
     min-width: 0;
@@ -137,6 +140,7 @@ h6 { font-size: 1rem; }
     .content-and-sidebar-wrapper {
         grid-template-columns: 1fr;
         padding-top: calc(var(--header-height-desktop) + var(--spacing-lg));
+        gap: var(--spacing-xl);
     }
 
     .noticias-sidebar {
@@ -154,6 +158,7 @@ h6 { font-size: 1rem; }
         padding-top: calc(var(--header-height-mobile) + var(--spacing-lg));
         padding-left: var(--spacing-md);
         padding-right: var(--spacing-md);
+        gap: var(--spacing-lg);
     }
 }
 
@@ -161,5 +166,38 @@ h6 { font-size: 1rem; }
     .content-and-sidebar-wrapper {
         padding-left: var(--spacing-sm);
         padding-right: var(--spacing-sm);
+        gap: var(--spacing-md);
+    }
+}
+
+@media (max-width: 992px) {
+    h1 {
+        font-size: 2.1rem;
+    }
+
+    h2 {
+        font-size: 1.8rem;
+    }
+
+    h3 {
+        font-size: 1.5rem;
+    }
+}
+
+@media (max-width: 640px) {
+    h1 {
+        font-size: 1.9rem;
+    }
+
+    h2 {
+        font-size: 1.55rem;
+    }
+
+    h3 {
+        font-size: 1.35rem;
+    }
+
+    body {
+        line-height: 1.55;
     }
 }

--- a/src/pages/Consulta.css
+++ b/src/pages/Consulta.css
@@ -186,6 +186,7 @@
 
     .search-box {
         padding: var(--spacing-lg);
+        width: 100%;
     }
 
     .results-box {
@@ -205,10 +206,16 @@
     .search-box {
         padding: var(--spacing-md);
         border-radius: 18px;
+        width: 100%;
     }
 
     .results-box {
         padding: var(--spacing-md);
         border-radius: 18px;
+    }
+
+    .search-button,
+    .download-pdf-button {
+        max-width: none;
     }
 }

--- a/src/pages/Contacto.css
+++ b/src/pages/Contacto.css
@@ -258,4 +258,8 @@
         padding: var(--spacing-md);
         border-radius: 18px;
     }
+
+    .contact-form button {
+        width: 100%;
+    }
 }

--- a/src/pages/Cotizar.css
+++ b/src/pages/Cotizar.css
@@ -254,10 +254,12 @@
         border-bottom-left-radius: 32px;
         border-bottom-right-radius: 32px;
         min-height: 320px;
+        text-align: center;
     }
 
     .cotizar-hero__content {
         gap: var(--spacing-sm);
+        justify-items: center;
     }
 
     .cotizar-highlights,
@@ -269,6 +271,7 @@
 
     .cotizar-portfolio-link__content {
         padding: var(--spacing-lg);
+        text-align: center;
     }
 }
 
@@ -284,5 +287,16 @@
     .cotizar-portfolio-link__button {
         width: 100%;
         justify-content: center;
+    }
+
+    .cotizar-highlights,
+    .cotizar-process,
+    .cotizar-form-section,
+    .cotizar-portfolio-link {
+        margin: 0 var(--spacing-sm);
+    }
+
+    .cotizar-process__content {
+        padding: var(--spacing-lg);
     }
 }

--- a/src/pages/Inicio.css
+++ b/src/pages/Inicio.css
@@ -15,6 +15,13 @@
     padding: var(--spacing-md) 0;
 }
 
+.inicio-button-wrapper {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+}
+
 .inicio-header {
     background: radial-gradient(circle at 20% 20%, rgba(250, 204, 21, 0.2), transparent 65%),
                 linear-gradient(135deg, rgba(93, 11, 11, 0.95), rgba(153, 27, 27, 0.92));
@@ -250,6 +257,10 @@
     .inicio-section {
         padding: var(--spacing-lg);
     }
+
+    .inicio-section p {
+        font-size: 1rem;
+    }
 }
 
 @media (max-width: 768px) {
@@ -267,6 +278,7 @@
 
     .inicio-section {
         padding: var(--spacing-lg);
+        text-align: center;
     }
 
     .inicio-section-title {
@@ -275,6 +287,16 @@
 
     .inicio-list {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        justify-items: center;
+    }
+
+    .inicio-list li {
+        width: 100%;
+        max-width: 320px;
+    }
+
+    .inicio-section p {
+        text-align: center;
     }
 }
 
@@ -301,5 +323,22 @@
 
     .inicio-list {
         grid-template-columns: 1fr;
+    }
+
+    .inicio-list li {
+        max-width: none;
+    }
+
+    .inicio-section {
+        text-align: left;
+    }
+
+    .inicio-section p {
+        text-align: left;
+    }
+
+    .inicio-button {
+        width: 100%;
+        text-align: center;
     }
 }

--- a/src/pages/Nosotros.css
+++ b/src/pages/Nosotros.css
@@ -23,7 +23,7 @@ body.no-scroll {
     line-height: 1.6;
     max-width: 1400px;
     margin: 0 auto;
-    padding: 0 var(--spacing-md, 16px);
+    padding: 0 var(--spacing-xl, 40px) var(--spacing-xl, 40px);
 }
 
 .nosotros-hero-section {
@@ -71,7 +71,7 @@ body.no-scroll {
 .accordion-sections-wrapper {
     max-width: 1200px;
     margin: 0 auto var(--spacing-xl, 40px);
-    padding: 0;
+    padding: 0 var(--spacing-md, 16px);
     box-sizing: border-box;
 }
 
@@ -541,6 +541,14 @@ body.no-scroll {
 }
 
 @media (max-width: 992px) {
+    .nosotros-main-container {
+        padding: 0 var(--spacing-lg, 24px) var(--spacing-xl, 40px);
+    }
+
+    .accordion-sections-wrapper {
+        padding: 0;
+    }
+
     .nosotros-h1 { font-size: 3rem; }
     .nosotros-hero-subtitle { font-size: 1.1rem; }
     .accordion-header { font-size: 1.6rem; padding: var(--spacing-md, 16px); }
@@ -553,6 +561,15 @@ body.no-scroll {
 }
 
 @media (max-width: 768px) {
+    .nosotros-main-container {
+        padding: 0 var(--spacing-md, 16px) var(--spacing-lg, 24px);
+    }
+
+    .nosotros-hero-section {
+        padding: 48px var(--spacing-md, 16px);
+        text-align: center;
+    }
+
     .nosotros-h1 { font-size: 2.6rem; }
     .nosotros-hero-subtitle { font-size: 1rem; }
     .accordion-header { font-size: 1.4rem; padding: var(--spacing-sm, 8px) var(--spacing-md, 16px); }
@@ -568,6 +585,14 @@ body.no-scroll {
 }
 
 @media (max-width: 480px) {
+    .nosotros-main-container {
+        padding: 0 var(--spacing-sm, 8px) var(--spacing-lg, 24px);
+    }
+
+    .accordion-sections-wrapper {
+        padding: 0;
+    }
+
     .nosotros-h1 { font-size: 2.2rem; }
     .nosotros-hero-subtitle { font-size: 0.95rem; }
     .accordion-header { font-size: 1.2rem; padding: var(--spacing-sm, 8px); }

--- a/src/pages/Portafolio.css
+++ b/src/pages/Portafolio.css
@@ -277,6 +277,11 @@
     .portafolio-main {
         padding: var(--spacing-xxl) var(--spacing-lg);
     }
+
+    .portafolio-section,
+    .service-detail-section {
+        padding: var(--spacing-xl);
+    }
 }
 
 @media (max-width: 768px) {
@@ -302,6 +307,11 @@
     .service-detail-section {
         padding: var(--spacing-lg);
     }
+
+    .portafolio-header p,
+    .portafolio-section__lead {
+        text-align: center;
+    }
 }
 
 @media (max-width: 520px) {
@@ -311,5 +321,14 @@
 
     .service-cards-grid {
         grid-template-columns: 1fr;
+    }
+
+    .portafolio-main {
+        padding: var(--spacing-xl) var(--spacing-sm);
+    }
+
+    .portafolio-section,
+    .service-detail-section {
+        padding: var(--spacing-md);
     }
 }


### PR DESCRIPTION
## Summary
- Ajusté los estilos globales para controlar el espaciado y la escala tipográfica en pantallas pequeñas, evitando desplazamientos horizontales.
- Refiné los estilos responsivos de las páginas principales (Inicio, Consulta, Cotizar, Contacto, Nosotros y Portafolio) para que se adapten mejor a móviles.
- Reacomodé elementos flotantes como el encabezado, el botón de emergencia y el chatbot para que mantengan un comportamiento consistente en teléfonos.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e56435e4b48330899a9dc28ee29a99